### PR TITLE
Fix memory allocation & access in AvxTextRender::adjustStride()

### DIFF
--- a/avxcommon/src/AvxTextRender.cpp
+++ b/avxcommon/src/AvxTextRender.cpp
@@ -92,13 +92,13 @@ namespace avxsynth
             strideBuf.nCairoStride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, trd.width);        
             
             {
-                strideBuf.pData = new unsigned char[trd.width*strideBuf.nCairoStride];
+                strideBuf.pData = new unsigned char[trd.height*strideBuf.nCairoStride];
                 if(NULL == strideBuf.pData)
                 {
                     throw AvxException
                     (
                         "Failed allocating %d bytes (%d x %d bytes) for Cairo surface",
-                        trd.width*strideBuf.nCairoStride, trd.width, strideBuf.nCairoStride
+                        trd.height*strideBuf.nCairoStride, trd.height, strideBuf.nCairoStride
                     );
                 }
 
@@ -110,7 +110,7 @@ namespace avxsynth
                     // single pass through this loop processes one 
                     // horizontal line
                     unsigned char* pSrc  = trd.originalBuffer + i*trd.originalStride;
-                    unsigned char* pDest = strideBuf.pData + (trd.height - i)*strideBuf.nCairoStride;
+                    unsigned char* pDest = strideBuf.pData + (trd.height - 1 - i)*strideBuf.nCairoStride;
                     for(int j = 0; j < trd.width; j++)
                     {
                         pDest[4 * j + 2] = pSrc[3*j + 0];
@@ -130,7 +130,7 @@ namespace avxsynth
             {
                 // single pass through this loop processes one 
                 // horizontal line
-                unsigned char* pSrc  = strideBuf.pData + (trd.height - i)*strideBuf.nCairoStride;
+                unsigned char* pSrc  = strideBuf.pData + (trd.height - 1 - i)*strideBuf.nCairoStride;
                 unsigned char* pDest = trd.originalBuffer + i*trd.originalStride;
                 for(int j = 0; j < trd.width; j++)
                 {


### PR DESCRIPTION
Fixes issue #2, crash with the following script:
 BlankClip(1000, 200, 400).killaudio.info

1) Allocate the right amount of memory for the PangoStrideBuf.
   Height and width were mixed up.

2) Off-by-one-row fix when repacking the pixels between original
   and cairo-style stride.
