### PR TITLE
add AM_PROG_AR to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES]) # Automake 1.11 is required for s
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_INSTALL
+AM_PROG_AR
 LT_INIT([dlopen disable-static])
 PKG_PROG_PKG_CONFIG
 


### PR DESCRIPTION
Otherwise I get this notification:
/usr/share/automake-1.14/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'