### PR TITLE
Added "<strings.h>" to support Ubuntu build

### DIFF
--- a/plugins/avxffms2/src/avsutils.cpp
+++ b/plugins/avxffms2/src/avsutils.cpp
@@ -19,6 +19,7 @@
 //  THE SOFTWARE.
 
 #include "avsutils.h"
+#include <strings.h>
 
 extern "C" {
 #include <libswscale/swscale.h>


### PR DESCRIPTION
Fixes build error on Ubuntu 14.04 LTS