### PR TITLE
Fixes #111 (compilation errors) as requested.

### DIFF
--- a/apps/AVXEdit/Makefile.am
+++ b/apps/AVXEdit/Makefile.am
@@ -58,4 +58,4 @@ src/qrc_application.cpp: application.qrc \
 	$(rcc_verbose)$(RCC) -name application $(srcdir)/application.qrc -o src/qrc_application.cpp
 
 src/moc_mainwindow.cpp: $(srcdir)/src/mainwindow.h
-	$(moc_verbose)$(MOC) $(AVXEdit_CPPFLAGS) $(CPPFLAGS) $< -o $@
+	$(moc_verbose)$(MOC) $(AVXEdit_CPPFLAGS) $< -o $@

--- a/plugins/avxframecapture/src/FrameRenderer.cpp
+++ b/plugins/avxframecapture/src/FrameRenderer.cpp
@@ -60,6 +60,7 @@ using namespace std;
 #define JVERSION    "8b  16-May-2010"
 
 #define JCOPYRIGHT  "Copyright (C) 2010, Thomas G. Lane, Guido Vollbeding"
+#define JCOPYRIGHT_SHORT  "(C) 2010, Thomas G. Lane, Guido Vollbeding"
 
 /* Create the add-on message string table. */
 


### PR DESCRIPTION
requested here: https://github.com/avxsynth/avxsynth/issues/111#issuecomment-90396133

Currently (commit 193702b7854c8398297c2f661902253055b47e01 being latest), for successful compilation I need to apply the two changes in this PR. (tested!)

Otherwise I get these 2 errors:

1:
In file included from src/FrameRenderer.cpp:70:0:
/usr/include/jerror.h:137:1: error: ‘JCOPYRIGHT_SHORT’ was not declared in this scope
 JMESSAGE(JMSG_COPYRIGHT, JCOPYRIGHT_SHORT)
 ^
Makefile:505: recipe for target 'src/libavxframecapture_la-FrameRenderer.lo' failed
make[1]: *** [src/libavxframecapture_la-FrameRenderer.lo] Error 1

2:

make[1]: Entering directory '/home/emacs/build/avxsynth-git/makepkg/avxsynth-git/src/avxsynth/apps/AVXEdit'
/usr/lib/qt4/bin/moc -I../../apps/avxframeserver/frameserverlib/src -I../../include  -march=native -O2 -pipe -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wno-trigraphs src/mainwindow.h -o src/moc_mainwindow.cpp
/usr/lib/qt4/bin/rcc -name application ./application.qrc -o src/qrc_application.cpp
moc: Invalid argument
Usage: moc [options] <header-file>
  -o<file>           write output to file rather than stdout
  -I<dir>            add dir to the include path for header files
  -E                 preprocess only; do not generate meta object code
  -D<macro>[=<def>]  define macro, with optional definition
  -U<macro>          undefine macro
  -i                 do not generate an #include statement
  -p<path>           path prefix for included file
  -f[<file>]         force #include, optional file name
  -nn                do not display notes
  -nw                do not display warnings
  @<file>            read additional options from file
  -v                 display version of moc
Makefile:815: recipe for target 'src/moc_mainwindow.cpp' failed
make[1]: *** [src/moc_mainwindow.cpp] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/emacs/build/avxsynth-git/makepkg/avxsynth-git/src/avxsynth/apps/AVXEdit'
Makefile:500: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1