### PR TITLE
Fix comparison in convolution.cpp

### DIFF
--- a/avxsynth/builtinfunctions/src/filters/convolution.cpp
+++ b/avxsynth/builtinfunctions/src/filters/convolution.cpp
@@ -158,7 +158,7 @@ void GeneralConvolution::initBuffers(IScriptEnvironment* env)
   pbyG = new BYTE[buffSize];
   pbyB = new BYTE[buffSize];
 
-  if(pbyA && pbyR && pbyG && pbyB == false)
+  if(!(pbyA && pbyR && pbyG && pbyB))
     env->ThrowError("GeneralConvolution: out of memory");
 }
 


### PR DESCRIPTION
Fix comparison in `convolution.cpp`.

Solution (provided by @ghost):
```
sed -i 's|(pbyA \&\& pbyR \&\& pbyG \&\& pbyB == false)|(!(pbyA \&\& pbyR \&\& pbyG \&\& pbyB))|' avxsynth/builtinfunctions/src/filters/convolution.cpp
```

Fixes avxsynth/avxsynth#117