### PR TITLE
Fix avxffms2 plugin due to changes in FFmpeg API

### DIFF
--- a/plugins/avxffms2/src/avssources.cpp
+++ b/plugins/avxffms2/src/avssources.cpp
@@ -185,12 +185,12 @@ void AvisynthVideoSource::InitOutputFormat(
 	TargetFormats[2] = FFMS_GetPixFmt("bgra");
 	TargetFormats[3] = -1;
 
-	// PIX_FMT_NV21 is misused as a return value different to the defined ones in the function
-	PixelFormat TargetPixelFormat = CSNameToPIXFMT(ConvertToFormatName, PIX_FMT_NV21);
-	if (TargetPixelFormat == PIX_FMT_NONE)
+	// AV_PIX_FMT_NV21 is misused as a return value different to the defined ones in the function
+	AVPixelFormat TargetPixelFormat = CSNameToPIXFMT(ConvertToFormatName, AV_PIX_FMT_NV21);
+	if (TargetPixelFormat == AV_PIX_FMT_NONE)
 		Env->ThrowError("FFVideoSource: Invalid colorspace name specified");
 
-	if (TargetPixelFormat != PIX_FMT_NV21) {
+	if (TargetPixelFormat != AV_PIX_FMT_NV21) {
 		TargetFormats[0] = TargetPixelFormat;
 		TargetFormats[1] = -1;
 	}
@@ -234,7 +234,7 @@ void AvisynthVideoSource::InitOutputFormat(
 	if (RFFMode > 0 && ResizeToHeight != F->EncodedHeight)
 		Env->ThrowError("FFVideoSource: Vertical scaling not allowed in RFF mode");
 
-	if (RFFMode > 0 && TargetPixelFormat != PIX_FMT_NV21)
+	if (RFFMode > 0 && TargetPixelFormat != AV_PIX_FMT_NV21)
 		Env->ThrowError("FFVideoSource: Only the default output colorspace can be used in RFF mode");
 
 	// set color information variables

--- a/plugins/avxffms2/src/avsutils.cpp
+++ b/plugins/avxffms2/src/avsutils.cpp
@@ -27,18 +27,18 @@ extern "C" {
 
 #define _stricmp strcasecmp
 
-PixelFormat CSNameToPIXFMT(const char *CSName, PixelFormat Default) {
+AVPixelFormat CSNameToPIXFMT(const char *CSName, AVPixelFormat Default) {
 	if (!_stricmp(CSName, ""))
 		return Default;
 	if (!_stricmp(CSName, "YV12"))
-		return PIX_FMT_YUV420P;
+		return AV_PIX_FMT_YUV420P;
 	if (!_stricmp(CSName, "YUY2"))
-		return PIX_FMT_YUYV422;
+		return AV_PIX_FMT_YUYV422;
 	if (!_stricmp(CSName, "RGB24"))
-		return PIX_FMT_BGR24;
+		return AV_PIX_FMT_BGR24;
 	if (!_stricmp(CSName, "RGB32"))
-		return PIX_FMT_RGB32;
-	return PIX_FMT_NONE;
+		return AV_PIX_FMT_RGB32;
+	return AV_PIX_FMT_NONE;
 }
 
 int ResizerNameToSWSResizer(const char *ResizerName) {

--- a/plugins/avxffms2/src/avsutils.h
+++ b/plugins/avxffms2/src/avsutils.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #include <ffmscompat.h>
 
-PixelFormat CSNameToPIXFMT(const char *CSName, PixelFormat Default);
+AVPixelFormat CSNameToPIXFMT(const char *CSName, AVPixelFormat Default);
 int ResizerNameToSWSResizer(const char *ResizerName);
 
 #endif

--- a/plugins/avxffms2/src/ffswscale.cpp
+++ b/plugins/avxffms2/src/ffswscale.cpp
@@ -28,15 +28,15 @@ SWScale::SWScale(PClip Child, int ResizeToWidth, int ResizeToHeight, const char 
 	OrigHeight = vi.height;
 	FlipOutput = vi.IsYUV();
 
-	PixelFormat ConvertFromFormat = PIX_FMT_NONE;
+	AVPixelFormat ConvertFromFormat = AV_PIX_FMT_NONE;
 	if (vi.IsYV12())
-		ConvertFromFormat = PIX_FMT_YUV420P;
+		ConvertFromFormat = AV_PIX_FMT_YUV420P;
 	if (vi.IsYUY2())
-		ConvertFromFormat = PIX_FMT_YUYV422;
+		ConvertFromFormat = AV_PIX_FMT_YUYV422;
 	if (vi.IsRGB24())
-		ConvertFromFormat = PIX_FMT_BGR24;
+		ConvertFromFormat = AV_PIX_FMT_BGR24;
 	if (vi.IsRGB32())
-		ConvertFromFormat = PIX_FMT_RGB32;
+		ConvertFromFormat = AV_PIX_FMT_RGB32;
 
 	if (ResizeToHeight <= 0)
 		ResizeToHeight = OrigHeight;
@@ -48,15 +48,15 @@ SWScale::SWScale(PClip Child, int ResizeToWidth, int ResizeToHeight, const char 
 	else
 		vi.width = ResizeToWidth;
 
-	PixelFormat ConvertToFormat = CSNameToPIXFMT(ConvertToFormatName, ConvertFromFormat);
-	if (ConvertToFormat == PIX_FMT_NONE)
+	AVPixelFormat ConvertToFormat = CSNameToPIXFMT(ConvertToFormatName, ConvertFromFormat);
+	if (ConvertToFormat == AV_PIX_FMT_NONE)
 		Env->ThrowError("SWScale: Invalid colorspace specified (%s)", ConvertToFormatName);
 
 	switch (ConvertToFormat) {
-		case PIX_FMT_YUV420P: vi.pixel_type = VideoInfo::CS_I420; break;
-		case PIX_FMT_YUYV422: vi.pixel_type = VideoInfo::CS_YUY2; break;
-		case PIX_FMT_BGR24: vi.pixel_type = VideoInfo::CS_BGR24; break;
-		case PIX_FMT_RGB32: vi.pixel_type = VideoInfo::CS_BGR32; break;
+		case AV_PIX_FMT_YUV420P: vi.pixel_type = VideoInfo::CS_I420; break;
+		case AV_PIX_FMT_YUYV422: vi.pixel_type = VideoInfo::CS_YUY2; break;
+		case AV_PIX_FMT_BGR24: vi.pixel_type = VideoInfo::CS_BGR24; break;
+		case AV_PIX_FMT_RGB32: vi.pixel_type = VideoInfo::CS_BGR32; break;
 	}
 
 	FlipOutput ^= vi.IsYUV();
@@ -65,10 +65,10 @@ SWScale::SWScale(PClip Child, int ResizeToWidth, int ResizeToHeight, const char 
 	if (Resizer == 0)
 		Env->ThrowError("SWScale: Invalid resizer specified (%s)", ResizerName);
 
-	if (ConvertToFormat == PIX_FMT_YUV420P && vi.height & 1)
+	if (ConvertToFormat == AV_PIX_FMT_YUV420P && vi.height & 1)
 		Env->ThrowError("SWScale: mod 2 output height required");
 
-	if ((ConvertToFormat == PIX_FMT_YUV420P || ConvertToFormat == PIX_FMT_YUYV422) && vi.width & 1)
+	if ((ConvertToFormat == AV_PIX_FMT_YUV420P || ConvertToFormat == AV_PIX_FMT_YUYV422) && vi.width & 1)
 		Env->ThrowError("SWScale: mod 2 output width required");
 
 	Context = GetSwsContext(

--- a/plugins/avxffms2/src/videoutils.cpp
+++ b/plugins/avxffms2/src/videoutils.cpp
@@ -29,7 +29,7 @@ extern "C" {
 #include <libavutil/opt.h>
 }
 
-SwsContext *GetSwsContext(int SrcW, int SrcH, PixelFormat SrcFormat, int SrcColorSpace, int SrcColorRange, int DstW, int DstH, PixelFormat DstFormat, int DstColorSpace, int DstColorRange, int64_t Flags) {
+SwsContext *GetSwsContext(int SrcW, int SrcH, AVPixelFormat SrcFormat, int SrcColorSpace, int SrcColorRange, int DstW, int DstH, AVPixelFormat DstFormat, int DstColorSpace, int DstColorRange, int64_t Flags) {
 	Flags |= SWS_FULL_CHR_H_INT | SWS_FULL_CHR_H_INP | SWS_ACCURATE_RND | SWS_BITEXACT;
 	SwsContext *Context = sws_alloc_context();
 	if (!Context) return 0;
@@ -123,9 +123,9 @@ enum BCSType {
 	cUNUSABLE
 };
 
-static BCSType GuessCSType(PixelFormat p) {
+static BCSType GuessCSType(AVPixelFormat p) {
 	// guessing the colorspace type from the name is kinda hackish but libav doesn't export this kind of metadata
-	if (av_pix_fmt_desc_get(p)->flags & PIX_FMT_HWACCEL)
+	if (av_pix_fmt_desc_get(p)->flags & AV_PIX_FMT_FLAG_HWACCEL)
 		return cUNUSABLE;
 	const char *n = av_get_pix_fmt_name(p);
 	if (strstr(n, "gray") || strstr(n, "mono") || strstr(n, "y400a"))
@@ -138,7 +138,7 @@ static BCSType GuessCSType(PixelFormat p) {
 }
 
 struct LossAttributes {
-	PixelFormat Format;
+	AVPixelFormat Format;
 	int ChromaUndersampling;
 	int ChromaOversampling;
 	int DepthDifference;
@@ -153,7 +153,7 @@ static int GetPseudoDepth(const AVPixFmtDescriptor &Desc) {
 	return depth + 1;
 }
 
-static LossAttributes CalculateLoss(PixelFormat Dst, PixelFormat Src) {
+static LossAttributes CalculateLoss(AVPixelFormat Dst, AVPixelFormat Src) {
 	const AVPixFmtDescriptor &SrcDesc = *av_pix_fmt_desc_get(Src);
 	const AVPixFmtDescriptor &DstDesc = *av_pix_fmt_desc_get(Dst);
 	BCSType SrcCS = GuessCSType(Src);
@@ -182,15 +182,15 @@ static LossAttributes CalculateLoss(PixelFormat Dst, PixelFormat Src) {
 	return Loss;
 }
 
-PixelFormat FindBestPixelFormat(const std::vector<PixelFormat> &Dsts, PixelFormat Src) {
+AVPixelFormat FindBestPixelFormat(const std::vector<AVPixelFormat> &Dsts, AVPixelFormat Src) {
 	// some trivial special cases to make sure there's as little conversion as possible
 	if (Dsts.empty())
-		return PIX_FMT_NONE;
+		return AV_PIX_FMT_NONE;
 	if (Dsts.size() == 1)
 		return Dsts[0];
 
 	// is the input in the output?
-	std::vector<PixelFormat>::const_iterator i = std::find(Dsts.begin(), Dsts.end(), Src);
+	std::vector<AVPixelFormat>::const_iterator i = std::find(Dsts.begin(), Dsts.end(), Src);
 	if (i != Dsts.end())
 		return Src;
 

--- a/plugins/avxffms2/src/videoutils.h
+++ b/plugins/avxffms2/src/videoutils.h
@@ -34,7 +34,7 @@ extern "C" {
 
 // swscale and pp-related functions
 int64_t GetSWSCPUFlags();
-SwsContext *GetSwsContext(int SrcW, int SrcH, PixelFormat SrcFormat, int SrcColorSpace, int SrcColorRange, int DstW, int DstH, PixelFormat DstFormat, int DstColorSpace, int DstColorRange, int64_t Flags);
+SwsContext *GetSwsContext(int SrcW, int SrcH, AVPixelFormat SrcFormat, int SrcColorSpace, int SrcColorRange, int DstW, int DstH, AVPixelFormat DstFormat, int DstColorSpace, int DstColorRange, int64_t Flags);
 AVColorSpace GetAssumedColorSpace(int Width, int Height);
 
 // timebase-related functions
@@ -42,6 +42,6 @@ void CorrectNTSCRationalFramerate(int *Num, int *Den);
 void CorrectTimebase(FFMS_VideoProperties *VP, FFMS_TrackTimeBase *TTimebase);
 
 // our implementation of avcodec_find_best_pix_fmt()
-PixelFormat FindBestPixelFormat(const std::vector<PixelFormat> &Dsts, PixelFormat Src);
+AVPixelFormat FindBestPixelFormat(const std::vector<AVPixelFormat> &Dsts, AVPixelFormat Src);
 
 void RegisterCustomParsers();


### PR DESCRIPTION
Fix avxffms2 plugin due to changes in FFmpeg API.

Solution:
```
find * -xtype f \( -name '*.cpp' -o -name '*.h' \) | while read -r file; do grep -hE '_FMT_' "${file}" &>/dev/null || continue; echo "${file}"; sed -i -re "s/(^|[^A-Z0-9_])(PIX_FMT_BGR24|PIX_FMT_NONE|PIX_FMT_NV21|PIX_FMT_RGB32|PIX_FMT_YUV420P|PIX_FMT_YUYV422)/\1AV_\2/g;" "${file}"; done;
```
```
find * -xtype f \( -name '*.cpp' -o -name '*.h' \) | while read -r file; do sed -i -re 's/(^|[^A-Za-z0-9_])(PixelFormat)/\1AV\2/g;' "${file}"; done;
```
```
find * -xtype f \( -name '*.cpp' -o -name '*.h' \) | while read -r file; do sed -i -re 's/(^|[^A-Za-z0-9_])(PIX_FMT_HWACCEL)/\1AV_PIX_FMT_FLAG_HWACCEL/g;' "${file}"; done;
```

Fixes avxsynth/avxsynth#118