### PR TITLE
Include <libavformat/avformat.h> where needed

### DIFF
--- a/plugins/avxffms2/src/avsutils.h
+++ b/plugins/avxffms2/src/avsutils.h
@@ -22,6 +22,7 @@
 #define AVSUTILS_H
 
 extern "C" {
+#include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
 }
 

--- a/plugins/avxffms2/src/ffswscale.h
+++ b/plugins/avxffms2/src/ffswscale.h
@@ -22,6 +22,7 @@
 #define FFSWSCALE_H
 
 extern "C" {
+#include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
 }
 


### PR DESCRIPTION
Include `<libavformat/avformat.h>` where needed.

Solution:
```
grep -lER ffmscompat.h * | while read -r file; do echo "${file}"; grep -F 'avformat.h' "${file}" &>/dev/null && continue; sed -i -re '1,/(avcodec|swscale|pixdesc)\.h[>"]/{s:(^.*(avcodec|swscale|pixdesc)\.h[>"]):#include <libavformat/avformat.h>\n\1:;}' "${file}"; done;
```

Fixes avxsynth/avxsynth#119