### PR TITLE
Do some dirty casting to fix the more strict gcc 10.2

### DIFF
--- a/avxsynth/core/src/core/avxsynth.cpp
+++ b/avxsynth/core/src/core/avxsynth.cpp
@@ -1827,7 +1827,8 @@ void* ScriptEnvironment::ManageCache(int key, void* data){
 // ScriptEnvironment class without extending the IScriptEnvironment
 // definition.
 
-  switch (key)
+  unsigned ikey = static_cast<unsigned>(key);
+  switch (ikey)
   {
   // Allow the cache to designate a VideoFrameBuffer as expired thus
   // allowing it to be reused in favour of any of it's older siblings.

--- a/avxsynth/core/src/core/parser/expression.cpp
+++ b/avxsynth/core/src/core/parser/expression.cpp
@@ -89,15 +89,15 @@ static const char * const StringSystemError(const unsigned code)
     return "Evaluate: System exception - Access Violation";
   case STATUS_IN_PAGE_ERROR:             // 0xc0000006
     return "Evaluate: System exception - In Page Error";
-  case STATUS_INVALID_HANDLE:            // 0xc0000008
+  case (unsigned)STATUS_INVALID_HANDLE:  // 0xc0000008
     return "Evaluate: System exception - Invalid Handle";
   case STATUS_NO_MEMORY:                 // 0xc0000017
     return "Evaluate: System exception - No Memory";
   case STATUS_ILLEGAL_INSTRUCTION:       // 0xc000001d
     return "Evaluate: System exception - Illegal Instruction";
-  case STATUS_NONCONTINUABLE_EXCEPTION:  // 0xc0000025
+  case (unsigned)STATUS_NONCONTINUABLE_EXCEPTION:  // 0xc0000025
     return "Evaluate: System exception - Noncontinuable Exception";
-  case STATUS_INVALID_DISPOSITION:       // 0xc0000026
+  case (unsigned)STATUS_INVALID_DISPOSITION:       // 0xc0000026
     return "Evaluate: System exception - Invalid Disposition";
   case STATUS_ARRAY_BOUNDS_EXCEEDED:     // 0xc000008c
     return "Evaluate: System exception - Array Bounds Exceeded";


### PR DESCRIPTION
To make this compile under Raspberry Pi OS Bullseye, I had to make some casts. They don't look nice, but I wanted to do it quickly.